### PR TITLE
Update dependency WebIDL2JS to v16.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,6 @@
 const DOMException = require("./webidl2js-wrapper.js");
 
 const sharedGlobalObject = { Error };
-DOMException.install(sharedGlobalObject);
+DOMException.install(sharedGlobalObject, ["Window"]);
 
 module.exports = sharedGlobalObject.DOMException;

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,9 +25,9 @@
       }
     },
     "acorn": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-      "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
       "dev": true
     },
     "acorn-jsx": {
@@ -1037,24 +1037,24 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.4.tgz",
+      "integrity": "sha512-iG9AK/dJLtJ0XNgTuDbSyNS3zECqDlAhnQW4CsNxBG3LQJBbHmRX1egw39DmtOdCAqY+dKXV+sgPgilNWUKMVw==",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.5"
       }
     },
     "mocha": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.2.2.tgz",
-      "integrity": "sha512-FgDS9Re79yU1xz5d+C4rv1G7QagNGHZ+iXF81hO8zY35YZZcLEsJVfFolfsqKFWunATEvNzMK0r/CwWd/szO9A==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.2.3.tgz",
+      "integrity": "sha512-0R/3FvjIGH3eEuG17ccFPk117XL2rWxatr81a57D+r/x2uTYZRbdZ4oVidEUMh2W2TJDa7MdAb12Lm2/qrKajg==",
       "dev": true,
       "requires": {
         "ansi-colors": "3.2.3",
@@ -1069,7 +1069,7 @@
         "js-yaml": "3.13.1",
         "log-symbols": "2.2.0",
         "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
+        "mkdirp": "0.5.4",
         "ms": "2.1.1",
         "node-environment-flags": "1.0.5",
         "object.assign": "4.1.0",
@@ -1077,8 +1077,8 @@
         "supports-color": "6.0.0",
         "which": "1.3.1",
         "wide-align": "1.1.3",
-        "yargs": "13.3.0",
-        "yargs-parser": "13.1.1",
+        "yargs": "13.3.2",
+        "yargs-parser": "13.1.2",
         "yargs-unparser": "1.6.0"
       },
       "dependencies": {
@@ -1090,6 +1090,12 @@
           "requires": {
             "ms": "^2.1.1"
           }
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
         },
         "glob": {
           "version": "7.1.3",
@@ -1105,11 +1111,28 @@
             "path-is-absolute": "^1.0.0"
           }
         },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
         "ms": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
         },
         "strip-json-comments": {
           "version": "2.0.1",
@@ -1124,6 +1147,24 @@
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
+          }
+        },
+        "yargs": {
+          "version": "13.3.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+          "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^5.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.1.2"
           }
         }
       }
@@ -1305,12 +1346,6 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
-    "pn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
-      "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
-      "dev": true
-    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -1318,9 +1353,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
+      "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
       "dev": true
     },
     "progress": {
@@ -1747,21 +1782,28 @@
       "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA=="
     },
     "webidl2": {
-      "version": "23.10.1",
-      "resolved": "https://registry.npmjs.org/webidl2/-/webidl2-23.10.1.tgz",
-      "integrity": "sha512-SK/KzMGgkPLN73HNqyU9tWPduireSzV6p/WAsmYYweI/ED19FC8+ymsi2InMX80+VjSvsfc3vA7UbMjXYWNPhA==",
+      "version": "23.12.1",
+      "resolved": "https://registry.npmjs.org/webidl2/-/webidl2-23.12.1.tgz",
+      "integrity": "sha512-CbBwugDZl4vO2hH6oY5ZxCZM+6OB3+k8tXzkKTk1y1w4eLExHKMXS/mtIMFBj2vA7JanD8toNcDCp4EH7J3gLg==",
       "dev": true
     },
     "webidl2js": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/webidl2js/-/webidl2js-12.0.0.tgz",
-      "integrity": "sha512-81Dpw+91iCOIi81ygTUKrH5mHyueglfR0Z3DSiTtW9xDq8ZFrAnqb3ifXaiBBqE02YUlhpJBnblmE3njvTf2Og==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/webidl2js/-/webidl2js-16.0.0.tgz",
+      "integrity": "sha512-cgboeEe6297x9QSRp8CXKLKjADWHDIyTxFYs9ky63Ztui8tMOJxGpEpvYmHDikBkCHNwzeRBWSF40Dc0uCZMEg==",
       "dev": true,
       "requires": {
-        "pn": "^1.1.0",
-        "prettier": "^1.19.1",
-        "webidl-conversions": "^5.0.0",
-        "webidl2": "^23.10.1"
+        "prettier": "^2.0.4",
+        "webidl-conversions": "^6.1.0",
+        "webidl2": "^23.11.0"
+      },
+      "dependencies": {
+        "webidl-conversions": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+          "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
+          "dev": true
+        }
       }
     },
     "which": {
@@ -1928,9 +1970,9 @@
       }
     },
     "yargs-parser": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-      "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
       "dev": true,
       "requires": {
         "camelcase": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "mkdirp": "^0.5.1",
     "mocha": "^6.2.2",
     "request": "^2.88.0",
-    "webidl2js": "^12.0.0"
+    "webidl2js": "^16.0.0"
   },
   "engines": {
     "node": ">=8"

--- a/src/DOMException.webidl
+++ b/src/DOMException.webidl
@@ -1,10 +1,9 @@
 // https://heycam.github.io/webidl/#idl-DOMException
 
-[
- Exposed=(Window,Worker),
- Constructor(optional DOMString message = "", optional DOMString name = "Error")
-]
+[Exposed=(Window,Worker)]
 interface DOMException { // but see below note about ECMAScript binding
+  constructor(optional DOMString message = "", optional DOMString name = "Error");
+
   readonly attribute DOMString name;
   readonly attribute DOMString message;
   readonly attribute unsigned short code;

--- a/test/test.js
+++ b/test/test.js
@@ -30,7 +30,7 @@ function createSharedSandbox() {
 
 function createWrapperSandbox() {
   const sandbox = Object.assign({ Error, Object, Function }, testharness);
-  WrapperDOMException.install(sandbox);
+  WrapperDOMException.install(sandbox, ["Window"]);
   return sandbox;
 }
 
@@ -66,7 +66,7 @@ describe("webidl2js Wrapper", () => {
   it("throws when installing DOMException on a global object without an Error constructor", () => {
     const badGlobal = {};
     assert.throws(() => {
-      WrapperDOMException.install(badGlobal);
+      WrapperDOMException.install(badGlobal, ["Window"]);
     }, Error);
 
     assert.equal("DOMException" in badGlobal, false);
@@ -75,7 +75,7 @@ describe("webidl2js Wrapper", () => {
   it("throws when installing DOMException on a global object with an invalid Error constructor", () => {
     const badGlobal = { Error: {} };
     assert.throws(() => {
-      WrapperDOMException.install(badGlobal);
+      WrapperDOMException.install(badGlobal, ["Window"]);
     }, Error);
 
     assert.equal("DOMException" in badGlobal, false);

--- a/webidl2js-wrapper.js
+++ b/webidl2js-wrapper.js
@@ -3,13 +3,13 @@ const DOMException = require("./lib/DOMException.js");
 
 // Special install function to make the DOMException inherit from Error.
 // https://heycam.github.io/webidl/#es-DOMException-specialness
-function installOverride(globalObject) {
+function install(globalObject, globalNames) {
   if (typeof globalObject.Error !== "function") {
     throw new Error("Internal error: Error constructor is not present on the given global object.");
   }
 
-  DOMException.install(globalObject);
+  DOMException.install(globalObject, globalNames);
   Object.setPrototypeOf(globalObject.DOMException.prototype, globalObject.Error.prototype);
 }
 
-module.exports = {...DOMException, install: installOverride };
+module.exports = { ...DOMException, install };


### PR DESCRIPTION
This makes it possible to make use of the `globalNames` parameter and the other features added since **WebIDL2JS v12.0**.